### PR TITLE
include utils in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="competitive_rl", version="0.1.0",
-    packages=['competitive_rl', 'competitive_rl.pong', 'competitive_rl.car_racing'],
+    packages=['competitive_rl', 'competitive_rl.pong', 'competitive_rl.car_racing', 'competitive_rl.utils'],
     install_requires=[
         "gym",
         "pygame==1.9.6",


### PR DESCRIPTION
It seems we need the `competitive_rl.utils` package to be installed. 
Otherwise it will raise error on `import competitive_rl`. 