### PR TITLE
Fix bugs in action repetition

### DIFF
--- a/competitive_rl/car_racing/car_racing_multi_players.py
+++ b/competitive_rl/car_racing/car_racing_multi_players.py
@@ -565,7 +565,7 @@ class CarRacing(gym.Env, EzPickle):
                     if self.done[i]:
                         continue
                     self.cars[i].step(1.0 / FPS)
-                    self.rewards[i] -= 0.1
+                    self.rewards[i] -= 0.1 / self.action_repeat
                     # We actually don't want to count fuel spent, we want car to be faster.
                     # self.reward -=  10 * self.car.fuel_spent / ENGINE_POWER
                     self.cars[i].fuel_spent = 0.0

--- a/competitive_rl/car_racing/car_racing_multi_players.py
+++ b/competitive_rl/car_racing/car_racing_multi_players.py
@@ -558,21 +558,20 @@ class CarRacing(gym.Env, EzPickle):
         self.ontrack_count += 1
         self.step_count += 1'''
 
-        step_rewards = {x: 0 for x in range(self.num_player)}
+        step_rewards = {x: 0.0 for x in range(self.num_player)}
         if action is not None:  # First step without action, called from reset()
             for _ in range(self.action_repeat):  # Action repetition
                 for i in self.cars.keys():
+                    if self.done[i]:
+                        continue
                     self.cars[i].step(1.0 / FPS)
                     self.rewards[i] -= 0.1
                     # We actually don't want to count fuel spent, we want car to be faster.
                     # self.reward -=  10 * self.car.fuel_spent / ENGINE_POWER
                     self.cars[i].fuel_spent = 0.0
-                    step_rewards[i] = self.rewards[i] - self.prev_rewards[i]
+                    step_rewards[i] += self.rewards[i] - self.prev_rewards[i]
                     self.prev_rewards[i] = self.rewards[i]
                     x, y = self.cars[i].hull.position
-
-                    self.info[i] = f"P{i}: Tiles_visited: {self.tile_visited_count[i]} / {len(self.track)}, "
-                    self.info[i] += f"rewards: {step_rewards[i]}"
 
                     if self.tile_visited_count[i] == len(self.track):
                         # print("car finishs all tiles")
@@ -582,13 +581,9 @@ class CarRacing(gym.Env, EzPickle):
                         # print("car out of playfield")
                         self.done[i] = True
 
-                    # if self.ontrack_count >= 190:
-                    #     print("Out of Road")
-                    #     self.done[i] = 1
-                    # step_rewards[i] = -50
-
                     if self.step_count > 1000:  # Maximum steps
                         self.done[i] = True
+
                 self.world.Step(1.0 / FPS, 6 * 30, 2 * 30)
                 self.t += 1.0 / FPS
                 self.ontrack_count += 1

--- a/competitive_rl/car_racing/car_racing_multi_players.py
+++ b/competitive_rl/car_racing/car_racing_multi_players.py
@@ -549,44 +549,50 @@ class CarRacing(gym.Env, EzPickle):
             else:
                 raise ValueError()
 
-        for _ in range(self.action_repeat):  # Action repetition
+        '''for _ in range(self.action_repeat):  # Action repetition
             for car in self.cars.values():
                 car.step(1.0 / FPS)
-            self.world.Step(1.0 / FPS, 6 * 30, 2 * 30)
+            self.world.Step(1.0 / FPS, 6 * 30, 2 * 30)'''
 
-        self.t += 1.0 / FPS
+        '''self.t += 1.0 / FPS
         self.ontrack_count += 1
-        self.step_count += 1
+        self.step_count += 1'''
 
         step_rewards = {x: 0 for x in range(self.num_player)}
         if action is not None:  # First step without action, called from reset()
-            for i in self.cars.keys():
-                self.rewards[i] -= 0.1
-                # We actually don't want to count fuel spent, we want car to be faster.
-                # self.reward -=  10 * self.car.fuel_spent / ENGINE_POWER
-                self.cars[i].fuel_spent = 0.0
-                step_rewards[i] = self.rewards[i] - self.prev_rewards[i]
-                self.prev_rewards[i] = self.rewards[i]
-                x, y = self.cars[i].hull.position
+            for _ in range(self.action_repeat):  # Action repetition
+                for i in self.cars.keys():
+                    self.cars[i].step(1.0 / FPS)
+                    self.rewards[i] -= 0.1
+                    # We actually don't want to count fuel spent, we want car to be faster.
+                    # self.reward -=  10 * self.car.fuel_spent / ENGINE_POWER
+                    self.cars[i].fuel_spent = 0.0
+                    step_rewards[i] = self.rewards[i] - self.prev_rewards[i]
+                    self.prev_rewards[i] = self.rewards[i]
+                    x, y = self.cars[i].hull.position
 
-                self.info[i] = f"P{i}: Tiles_visited: {self.tile_visited_count[i]} / {len(self.track)}, "
-                self.info[i] += f"rewards: {step_rewards[i]}"
+                    self.info[i] = f"P{i}: Tiles_visited: {self.tile_visited_count[i]} / {len(self.track)}, "
+                    self.info[i] += f"rewards: {step_rewards[i]}"
 
-                if self.tile_visited_count[i] == len(self.track):
-                    # print("car finishs all tiles")
-                    self.done[i] = True
+                    if self.tile_visited_count[i] == len(self.track):
+                        # print("car finishs all tiles")
+                        self.done[i] = True
 
-                if abs(x) > PLAYFIELD or abs(y) > PLAYFIELD:
-                    # print("car out of playfield")
-                    self.done[i] = True
+                    if abs(x) > PLAYFIELD or abs(y) > PLAYFIELD:
+                        # print("car out of playfield")
+                        self.done[i] = True
 
-                # if self.ontrack_count >= 190:
-                #     print("Out of Road")
-                #     self.done[i] = 1
-                # step_rewards[i] = -50
+                    # if self.ontrack_count >= 190:
+                    #     print("Out of Road")
+                    #     self.done[i] = 1
+                    # step_rewards[i] = -50
 
-                if self.step_count > 1000:  # Maximum steps
-                    self.done[i] = True
+                    if self.step_count > 1000:  # Maximum steps
+                        self.done[i] = True
+                self.world.Step(1.0 / FPS, 6 * 30, 2 * 30)
+                self.t += 1.0 / FPS
+                self.ontrack_count += 1
+                self.step_count += 1
 
         # Centralize the logic of rendering observation state into the step function
         original_follow = self.camera_follow

--- a/competitive_rl/car_racing/test_car_racing.py
+++ b/competitive_rl/car_racing/test_car_racing.py
@@ -3,21 +3,38 @@ import gym
 
 register_car_racing()
 
-if __name__ == '__main__':
-    # envs = make_car_racing("cCarRacing-v0", 0, 0)()
-    # obs = envs.reset()
-    # for _ in range(10000):
-    #     _, _, d, _ = envs.step(envs.action_space.sample())
-    #     envs.render("human")
-    #     if d:
-    #         envs.reset()
-    # print("Return obs shape: ", obs.shape)
-    # print("Return obs shape: ", obs.shape)
+
+def test_blackbox():
     e = gym.make("cCarRacing-v0")
     e.reset()
-    for _ in range(10000):
+    for _ in range(100):
         _, _, d, _ = e.step(e.action_space.sample())
         e.render("human")
         if d:
             e.reset()
     e.close()
+
+
+def test_action_repetition():
+    e = gym.make("cCarRacing-v0", action_repeat=1)
+    e.seed(0)
+    e.reset()
+    for _ in range(100 * 2):
+        e.render("human")
+        ret = e.step([0.0, 1])
+    print(ret)
+    e.close()
+
+    e = gym.make("cCarRacing-v0", action_repeat=5)
+    e.seed(0)
+    e.reset()
+    for _ in range(20 * 2):
+        e.render("human")
+        ret = e.step([0.0, 1])
+    print(ret)
+    e.close()
+
+
+if __name__ == '__main__':
+    test_blackbox()
+    test_action_repetition()


### PR DESCRIPTION
In previous implementation, we don't make the reward during action repetition exposed to external users.

But this may cause problem if we wish to make the following scenario identical:

1. set action_repeat to 5 and step the environment for once.
2. set action_repeat to 1 and step the environment for 5 times.

So this PR solves this issue.